### PR TITLE
fix: correct base64 fallback decoding and use crypto random for padding

### DIFF
--- a/packages/builder/lib/base64.ts
+++ b/packages/builder/lib/base64.ts
@@ -17,7 +17,7 @@ export const base64UrlEncode = (
 
   // Use environment-specific encoding
   let base64: string;
-  if (typeof globalThis !== 'undefined' && 'btoa' in globalThis) {
+  if (typeof globalThis !== 'undefined' && typeof globalThis.btoa === 'function') {
     // Browser environment
     base64 = globalThis.btoa(text);
   } else {
@@ -61,7 +61,7 @@ export const base64UrlDecode = (input: string): ArrayBuffer => {
   const base64 = base64UrlDecodeString(input);
 
   // Decode based on environment
-  if (typeof globalThis !== 'undefined' && 'atob' in globalThis) {
+  if (typeof globalThis !== 'undefined' && typeof globalThis.atob === 'function') {
     // Browser environment
     const binaryString = globalThis.atob(base64);
     const bytes = new Uint8Array(binaryString.length);
@@ -71,5 +71,9 @@ export const base64UrlDecode = (input: string): ArrayBuffer => {
     return bytes.buffer;
   }
   // Node.js environment
-  return Buffer.from(base64, 'base64').buffer;
+  const buffer = Buffer.from(base64, 'base64');
+  return buffer.buffer.slice(
+    buffer.byteOffset,
+    buffer.byteOffset + buffer.byteLength,
+  );
 };

--- a/packages/builder/lib/payload.ts
+++ b/packages/builder/lib/payload.ts
@@ -216,7 +216,7 @@ const padPayload = (payload: Uint8Array): Uint8Array<ArrayBuffer> => {
   const maxRandomPadding = Math.min(100, availableSpace);
   const paddingSize =
     maxRandomPadding > 0
-      ? Math.floor(Math.random() * (maxRandomPadding + 1))
+      ? crypto.getRandomValues(new Uint8Array(1))[0] % (maxRandomPadding + 1)
       : 0;
 
   const paddingArray = new ArrayBuffer(

--- a/packages/builder/test/unit.test.ts
+++ b/packages/builder/test/unit.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'vitest';
+import { base64UrlDecode } from '../lib/base64.js';
 import { buildPushHTTPRequest } from '../lib/main.js';
 import type {
   BuilderOptions,
@@ -214,6 +215,35 @@ describe('Subscription Keys Validation', () => {
         createOptions({ subscription: invalidSubscription }),
       ),
     ).rejects.toThrow('Invalid input');
+  });
+});
+
+// ============================================================================
+// Base64 Decoding Tests
+// ============================================================================
+describe('Base64 URL Decoding', () => {
+  test('decodes to exact byte length in default runtime path', () => {
+    const decoded = new Uint8Array(base64UrlDecode('AQ'));
+
+    expect(decoded).toEqual(new Uint8Array([1]));
+    expect(decoded.byteLength).toBe(1);
+  });
+
+  test('decodes to exact byte length in Buffer fallback path', () => {
+    const originalAtob = globalThis.atob;
+    // Force Node fallback path to verify sliced ArrayBuffer behavior.
+    // `Buffer#buffer` alone would expose backing store, not exact bytes.
+    // @ts-expect-error test override
+    globalThis.atob = undefined;
+
+    try {
+      const decoded = new Uint8Array(base64UrlDecode('AQ'));
+
+      expect(decoded).toEqual(new Uint8Array([1]));
+      expect(decoded.byteLength).toBe(1);
+    } finally {
+      globalThis.atob = originalAtob;
+    }
   });
 });
 


### PR DESCRIPTION
## What changed

Three small hardening changes in `@pushforge/builder`:

1. Fixed base64 decode fallback in Node.
2. Added regression tests for exact decoded byte length.
3. Replaced `Math.random()` padding-size selection with crypto RNG.

## 1. Base64 decode fix

File:
- [packages/builder/lib/base64.ts](/mnt/c/projects/real/copenhagenatomics/ca-cloud/apps/pushforge/packages/builder/lib/base64.ts)

Old Node fallback did this:

```ts
return Buffer.from(base64, 'base64').buffer;
```

Problem:
- `Buffer` is often view into larger backing `ArrayBuffer`.
- `.buffer` returns whole backing memory, not exact decoded bytes.

So caller could get wrong `ArrayBuffer.byteLength`.

New code slices exact region:

```ts
const buffer = Buffer.from(base64, 'base64');
return buffer.buffer.slice(
  buffer.byteOffset,
  buffer.byteOffset + buffer.byteLength,
);
```

Also tightened runtime checks:
- `typeof globalThis.atob === 'function'`
- `typeof globalThis.btoa === 'function'`

This avoids entering browser path when property exists but is not callable.

## 2. Regression tests

File:
- [packages/builder/test/unit.test.ts](/mnt/c/projects/real/copenhagenatomics/ca-cloud/apps/pushforge/packages/builder/test/unit.test.ts)

Added tests for:
- normal decode path returns exact 1-byte result
- forced Buffer fallback path also returns exact 1-byte result

These tests protect against future regressions in base64 decode behavior.

## 3. Crypto RNG for padding size

File:
- [packages/builder/lib/payload.ts](/mnt/c/projects/real/copenhagenatomics/ca-cloud/apps/pushforge/packages/builder/lib/payload.ts)

Old code used:

```ts
Math.random()
```

New code uses:

```ts
crypto.getRandomValues(new Uint8Array(1))[0]
```

Why:
- padding randomness should come from cryptographic RNG, same as other sensitive random values in this package
- small cleanup, more consistent with security-sensitive code

## Verification

Ran locally:

```sh
pnpm build
pnpm -C packages/builder exec vitest run test/unit.test.ts
```

Results:
- build passed
- unit tests passed: `48/48`
